### PR TITLE
Update Compose navigation to v2.8.0-rc01

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -180,17 +180,6 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
-          <option name="api" value="31" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="q2q" />
-          <option name="id" value="q2q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy Z Fold3" />
-          <option name="screenDensity" value="420" />
-          <option name="screenX" value="1768" />
-          <option name="screenY" value="2208" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="q5q" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -74,6 +74,4 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     androidTestImplementation(libs.androidx.navigation.testing)
-
-
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.example.typesafecomposenavigation"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.typesafecomposenavigation"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/androidTest/java/com/example/typesafecomposenavigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/example/typesafecomposenavigation/NavigationTest.kt
@@ -9,11 +9,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
-
 @RunWith(AndroidJUnit4::class)
 class NavigationTest {
-
-
     @Test
     fun testNavigation() {
         val detail = RecipeDestinations.RecipeDetails(2)
@@ -22,9 +19,6 @@ class NavigationTest {
 
         val navDetails: RecipeDestinations.RecipeDetails = savedStateHandle.toRoute()
 
-
         assertEquals(navDetails.recipeId, detail.recipeId)
     }
-
-
 }

--- a/app/src/main/java/com/example/typesafecomposenavigation/model/Ingredient.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/model/Ingredient.kt
@@ -3,4 +3,4 @@ package com.example.typesafecomposenavigation.model
 data class Ingredient(
     val name: String,
     val amount: String,
-    )
+)

--- a/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeModel.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeModel.kt
@@ -8,5 +8,5 @@ data class RecipeModel(
     val ingredients: List<Ingredient>,
     val steps: List<String>,
     val servings: Int,
-    val isFavorite: Boolean = false
+    val isFavorite: Boolean = false,
 )

--- a/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
@@ -2,11 +2,11 @@ package com.example.typesafecomposenavigation.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable
-@Parcelize
-enum class RecipeType : Parcelable {
+
+enum class RecipeType {
     Breakfast,
     Lunch,
     Supper,

--- a/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
@@ -1,5 +1,8 @@
 package com.example.typesafecomposenavigation.model
 
+import androidx.annotation.Keep
+
+@Keep
 enum class RecipeType {
     Breakfast,
     Lunch,

--- a/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/model/RecipeType.kt
@@ -1,21 +1,14 @@
 package com.example.typesafecomposenavigation.model
 
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-
 enum class RecipeType {
     Breakfast,
     Lunch,
     Supper,
-    Snack
+    Snack,
 }
-
 
 enum class DifficultyLevel {
     Beginner,
     Intermediate,
-    Advanced
+    Advanced,
 }

--- a/app/src/main/java/com/example/typesafecomposenavigation/screens/category/CategoryRecipes.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/screens/category/CategoryRecipes.kt
@@ -21,15 +21,13 @@ import com.example.typesafecomposenavigation.model.RecipeModel
 import com.example.typesafecomposenavigation.model.RecipeType
 import com.example.typesafecomposenavigation.screens.common.RecipeListScreen
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CategoryRecipesScreen(
     recipeType: RecipeType,
     onBackPressed: () -> Unit,
-    onRecipeClicked: (Int) -> Unit
+    onRecipeClicked: (Int) -> Unit,
 ) {
-
     var recipes by remember {
         mutableStateOf(emptyList<RecipeModel>())
     }
@@ -39,27 +37,19 @@ fun CategoryRecipesScreen(
             IconButton(onClick = onBackPressed) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "go back"
+                    contentDescription = "go back",
                 )
             }
         })
     }) {
-
         RecipeListScreen(
             modifier = Modifier.padding(top = it.calculateTopPadding()),
             recipes = recipes,
-            onRecipeClicked
+            onRecipeClicked,
         )
-
     }
 
-
-
-
-
     LaunchedEffect(recipeType) {
-
         recipes = RecipeRepository.getRecipesByType(recipeType)
-
     }
 }

--- a/app/src/main/java/com/example/typesafecomposenavigation/screens/recipelist/AllRecipeListScreen.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/screens/recipelist/AllRecipeListScreen.kt
@@ -13,16 +13,16 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import com.example.typesafecomposenavigation.model.RecipeModel
 import com.example.typesafecomposenavigation.screens.common.RecipeListScreen
 
-
 /*
 Recipe List views
  */
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-
-fun AllRecipesScreen(recipes: List<RecipeModel>, onRecipeClicked: (recipeId: Int) -> Unit) {
-
+fun AllRecipesScreen(
+    recipes: List<RecipeModel>,
+    onRecipeClicked: (recipeId: Int) -> Unit,
+) {
     val scrollBehavior =
         TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     Scaffold(
@@ -31,21 +31,14 @@ fun AllRecipesScreen(recipes: List<RecipeModel>, onRecipeClicked: (recipeId: Int
             TopAppBar(
                 title = { Text(text = "My Recipes") },
                 scrollBehavior = scrollBehavior,
-
-                )
-        }
+            )
+        },
     ) { padding ->
 
         RecipeListScreen(
             modifier = Modifier.padding(top = padding.calculateTopPadding()),
             recipes,
-            onRecipeClicked
+            onRecipeClicked,
         )
-
-
     }
-
-
 }
-
-

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
@@ -56,7 +56,6 @@ fun AppNavigation(
             }
         }
         composable<RecipeDestinations.CategoryRecipes>(
-            // typeMap = mapOf(typeOf<RecipeType>() to NavType.EnumType(RecipeType::class.java))
             // we are using the custom navtype for demonstration purposes,but it is not required we can use NavType.EnumType
             // typeMap = mapOf(typeOf<RecipeType>() to CategoryNavigationType)
         ) { backStackEntry ->

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
@@ -3,6 +3,7 @@ package com.example.typesafecomposenavigation.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
@@ -72,9 +73,9 @@ fun AppNavigation(
 
         }
         composable<RecipeDestinations.CategoryRecipes>(
-            // typeMap = mapOf(typeOf<RecipeType>() to NavType.EnumType(RecipeType::class.java))
+           typeMap = mapOf(typeOf<RecipeType>() to NavType.EnumType(RecipeType::class.java))
             // we are using the custom navtype for demonstration purposes,but it is not required we can use NavType.EnumType
-            typeMap = mapOf(typeOf<RecipeType>() to CategoryNavigationType)
+           // typeMap = mapOf(typeOf<RecipeType>() to CategoryNavigationType)
         ) { backStackEntry ->
 
             val category: RecipeDestinations.CategoryRecipes =

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
@@ -3,45 +3,34 @@ package com.example.typesafecomposenavigation.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.example.typesafecomposenavigation.data.RecipeRepository
-import com.example.typesafecomposenavigation.model.RecipeType
 import com.example.typesafecomposenavigation.screens.category.CategoryRecipesScreen
 import com.example.typesafecomposenavigation.screens.category.CategoryScreen
 import com.example.typesafecomposenavigation.screens.favorites.FavoriteRecipesScreen
 import com.example.typesafecomposenavigation.screens.recipedetail.RecipeDetailPage
 import com.example.typesafecomposenavigation.screens.recipelist.AllRecipesScreen
-import kotlin.reflect.typeOf
-
 
 @Composable
 fun AppNavigation(
     navController: NavHostController,
     startDestination: RecipeDestinations = RecipeDestinations.Recipes,
-    modifier: Modifier
+    modifier: Modifier,
 ) {
-
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        modifier = modifier
+        modifier = modifier,
     ) {
-
-
         composable<RecipeDestinations.Recipes> {
-
-
             AllRecipesScreen(RecipeRepository.getAllRecipes()) { recipeId ->
                 navController.navigate(RecipeDestinations.RecipeDetails(recipeId)) {
                     launchSingleTop = true
                 }
             }
-
         }
-
 
         composable<RecipeDestinations.RecipeDetails> { backStackEntry ->
             val recipeDetails: RecipeDestinations.RecipeDetails = backStackEntry.toRoute()
@@ -49,12 +38,9 @@ fun AppNavigation(
             RecipeDetailPage(recipeDetails.recipeId) {
                 navController.navigateUp()
             }
-
         }
 
         composable<RecipeDestinations.Favorites> {
-
-
             FavoriteRecipesScreen(onRecipeClicked = { recipeId ->
                 navController.navigate(RecipeDestinations.RecipeDetails(recipeId)) {
                     launchSingleTop = true
@@ -62,20 +48,17 @@ fun AppNavigation(
             }) {
                 navController.navigate(RecipeDestinations.Recipes)
             }
-
         }
 
         composable<RecipeDestinations.Category> {
-
             CategoryScreen {
                 navController.navigate(RecipeDestinations.CategoryRecipes(it))
             }
-
         }
         composable<RecipeDestinations.CategoryRecipes>(
-           typeMap = mapOf(typeOf<RecipeType>() to NavType.EnumType(RecipeType::class.java))
+            // typeMap = mapOf(typeOf<RecipeType>() to NavType.EnumType(RecipeType::class.java))
             // we are using the custom navtype for demonstration purposes,but it is not required we can use NavType.EnumType
-           // typeMap = mapOf(typeOf<RecipeType>() to CategoryNavigationType)
+            // typeMap = mapOf(typeOf<RecipeType>() to CategoryNavigationType)
         ) { backStackEntry ->
 
             val category: RecipeDestinations.CategoryRecipes =
@@ -83,13 +66,10 @@ fun AppNavigation(
 
             CategoryRecipesScreen(
                 category.type,
-                onBackPressed = { navController.navigateUp() }) { recipeId ->
+                onBackPressed = { navController.navigateUp() },
+            ) { recipeId ->
                 navController.navigate(RecipeDestinations.RecipeDetails(recipeId))
             }
-
-
         }
     }
-
-
 }

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/AppNavigation.kt
@@ -64,7 +64,7 @@ fun AppNavigation(
                 backStackEntry.toRoute<RecipeDestinations.CategoryRecipes>()
 
             CategoryRecipesScreen(
-                category.type,
+                recipeType = category.type,
                 onBackPressed = { navController.navigateUp() },
             ) { recipeId ->
                 navController.navigate(RecipeDestinations.RecipeDetails(recipeId))

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/Destinations.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/Destinations.kt
@@ -1,7 +1,5 @@
 package com.example.typesafecomposenavigation.ui.navigation
 
-import android.os.Build
-import android.os.Bundle
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.GridView
@@ -10,14 +8,10 @@ import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Restaurant
 import androidx.compose.ui.graphics.vector.ImageVector
-
 import com.example.typesafecomposenavigation.model.RecipeType
 import kotlinx.serialization.Serializable
 
-
-
 sealed class RecipeDestinations {
-
     @Serializable
     data object Recipes : RecipeDestinations()
 
@@ -25,45 +19,46 @@ sealed class RecipeDestinations {
     data object Favorites : RecipeDestinations()
 
     @Serializable
-    data class RecipeDetails(val recipeId: Int) : RecipeDestinations()
+    data class RecipeDetails(
+        val recipeId: Int,
+    ) : RecipeDestinations()
 
     @Serializable
     data object Category : RecipeDestinations()
 
     @Serializable
-    data class CategoryRecipes(val type: RecipeType) : RecipeDestinations()
-
+    data class CategoryRecipes(
+        val type: RecipeType,
+    ) : RecipeDestinations()
 }
 
 enum class TopLevelDestinations(
     val label: String,
     val selectedIcon: ImageVector,
     val unselectedIcon: ImageVector,
-    val route: RecipeDestinations
+    val route: RecipeDestinations,
 ) {
-
-
     Recipes(
         label = "Recipes",
         selectedIcon = Icons.Filled.Restaurant,
         unselectedIcon = Icons.Outlined.Restaurant,
-        route = RecipeDestinations.Recipes
+        route = RecipeDestinations.Recipes,
     ),
     Favorites(
         label = "Favorites",
         selectedIcon = Icons.Filled.Favorite,
         unselectedIcon = Icons.Outlined.Favorite,
-        route = RecipeDestinations.Favorites
+        route = RecipeDestinations.Favorites,
     ),
     Category(
         label = "Category",
         selectedIcon = Icons.Filled.GridView,
         unselectedIcon = Icons.Outlined.GridView,
-        route = RecipeDestinations.Category
-    )
+        route = RecipeDestinations.Category,
+    ),
 }
 //
-//val CategoryNavigationType = object : NavType<RecipeType>(isNullableAllowed = false) {
+// val CategoryNavigationType = object : NavType<RecipeType>(isNullableAllowed = false) {
 //    override fun get(bundle: Bundle, key: String): RecipeType? {
 //        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 //            bundle.getParcelable(key, RecipeType::class.java)
@@ -87,4 +82,4 @@ enum class TopLevelDestinations(
 //    }
 //
 //
-//}
+// }

--- a/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/Destinations.kt
+++ b/app/src/main/java/com/example/typesafecomposenavigation/ui/navigation/Destinations.kt
@@ -10,11 +10,10 @@ import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Restaurant
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.navigation.NavType
+
 import com.example.typesafecomposenavigation.model.RecipeType
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
+
 
 
 sealed class RecipeDestinations {
@@ -63,29 +62,29 @@ enum class TopLevelDestinations(
         route = RecipeDestinations.Category
     )
 }
-
-val CategoryNavigationType = object : NavType<RecipeType>(isNullableAllowed = false) {
-    override fun get(bundle: Bundle, key: String): RecipeType? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            bundle.getParcelable(key, RecipeType::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            bundle.getParcelable(key)
-        }
-
-    }
-
-    override fun parseValue(value: String): RecipeType {
-        return Json.decodeFromString<RecipeType>(value)
-    }
-
-    override fun serializeAsValue(value: RecipeType): String {
-        return Json.encodeToString(value)
-    }
-
-    override fun put(bundle: Bundle, key: String, value: RecipeType) {
-        bundle.putParcelable(key, value)
-    }
-
-
-}
+//
+//val CategoryNavigationType = object : NavType<RecipeType>(isNullableAllowed = false) {
+//    override fun get(bundle: Bundle, key: String): RecipeType? {
+//        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+//            bundle.getParcelable(key, RecipeType::class.java)
+//        } else {
+//            @Suppress("DEPRECATION")
+//            bundle.getParcelable(key)
+//        }
+//
+//    }
+//
+//    override fun parseValue(value: String): RecipeType {
+//        return Json.decodeFromString<RecipeType>(value)
+//    }
+//
+//    override fun serializeAsValue(value: RecipeType): String {
+//        return Json.encodeToString(value)
+//    }
+//
+//    override fun put(bundle: Bundle, key: String, value: RecipeType) {
+//        bundle.putParcelable(key, value)
+//    }
+//
+//
+//}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.2"
+agp = "8.5.2"
 kotlin = "2.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
@@ -8,7 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.4"
 activityCompose = "1.9.1"
 composeBom = "2024.06.00"
-navigationCompose = "2.8.0-beta06"
+navigationCompose = "2.8.0-rc01"
 kotlinx-serialization = "1.7.1"
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 07 11:00:28 EAT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update the compose navigation library to the latest release candidate .
This version doesn't  need the enum typemap to be included during navigation but the enums used as args have to be annotated with @Keep if minification is used in release builds